### PR TITLE
Add fireResistant() to Netherite Cloud Boots for Create compatibility

### DIFF
--- a/neoforge/src/main/java/com/tiviacz/cloudboots/neoforge/init/ModItems.java
+++ b/neoforge/src/main/java/com/tiviacz/cloudboots/neoforge/init/ModItems.java
@@ -15,6 +15,6 @@ public class ModItems {
     public static final DeferredItem<Item> IRON_CLOUD_BOOTS = ITEMS.register("iron_cloud_boots", () -> new CloudBootsItem(ModArmorMaterials.IRON_CLOUD, new Item.Properties()));
     public static final DeferredItem<Item> GOLD_CLOUD_BOOTS = ITEMS.register("gold_cloud_boots", () -> new CloudBootsItem(ModArmorMaterials.GOLD_CLOUD, new Item.Properties()));
     public static final DeferredItem<Item> DIAMOND_CLOUD_BOOTS = ITEMS.register("diamond_cloud_boots", () -> new CloudBootsItem(ModArmorMaterials.DIAMOND_CLOUD, new Item.Properties()));
-    public static final DeferredItem<Item> NETHERITE_CLOUD_BOOTS = ITEMS.register("netherite_cloud_boots", () -> new CloudBootsItem(ModArmorMaterials.NETHERITE_CLOUD, new Item.Properties()));
+    public static final DeferredItem<Item> NETHERITE_CLOUD_BOOTS = ITEMS.register("netherite_cloud_boots", () -> new CloudBootsItem(ModArmorMaterials.NETHERITE_CLOUD, new Item.Properties().fireResistant()));
     public static final DeferredItem<Item> GOLDEN_FEATHER = ITEMS.register("golden_feather", () -> new GoldenFeatherItem(new Item.Properties()));
 }


### PR DESCRIPTION
Netherite Cloud Boots are now marked as fire resistant, allowing them to be used as valid boots for Create's Netherite Diving Suit. Create's NetheriteDivingHandler checks for DataComponents.FIRE_RESISTANT to check for compatibility.
Reference: https://github.com/KyaniteMods/DeeperAndDarker/pull/434